### PR TITLE
Add file created when using add -p

### DIFF
--- a/gitcommitautosave.py
+++ b/gitcommitautosave.py
@@ -18,6 +18,6 @@ class GitCommitAutoSave(sublime_plugin.EventListener):
 
 
 def is_git_file(path):
-	git_files = ('COMMIT_EDITMSG', 'git-rebase-todo', 'MERGE_MSG', 'PULLREQ_EDITMSG')
+	git_files = ('COMMIT_EDITMSG', 'git-rebase-todo', 'MERGE_MSG', 'PULLREQ_EDITMSG', 'addp-hunk-edit.diff')
 	if path and any(path.endswith(name) for name in git_files):
 		return True


### PR DESCRIPTION
When using 'git add -p' or 'git checkout -p', if the user chooses
to manually edit the .diff file, Git creates a file called
'addp-hunk-edit.diff' (same file name for both operations).